### PR TITLE
feat: merge password rules updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# passwordmgr-related-realms-updater
+# passwordmgr-remote-settings-updater
 
-Script that adds new related websites to the "websites-with-shared-credential-backends" Remote Setting collection via [Apple's open sourced password manager resources](https://github.com/apple/password-manager-resources/blob/e0d5ba899c57482b06776a18c56b1ad714efd928/quirks/websites-with-shared-credential-backends.json).
+Script that adds new related websites to the "websites-with-shared-credential-backends" Remote Setting collection via [Apple's open sourced password manager resources](https://github.com/apple/password-manager-resources/blob/e0d5ba899c57482b06776a18c56b1ad714efd928/quirks/websites-with-shared-credential-backends.json) and adds new password rules to the "password-rules" Remote Setting collection via [Apple's open sourced password manager rules](https://github.com/apple/password-manager-resources/blob/main/quirks/password-rules.json).
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "update-websites-with-shared-credential-backends",
-  "version": "0.0.1",
-  "description": "Updates the 'websites-with-shared-credential-backends' collection on Remote Settings",
+  "name": "update-passwordmgr-remote-settings-collections",
+  "version": "0.0.2",
+  "description": "Updates the 'websites-with-shared-credential-backends' and 'password-rules' collections on Remote Settings",
   "author": "Tim Giles",
   "main": "index.js",
   "engines": {
@@ -14,13 +14,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mozilla/passwordmgr-related-realms-updater.git"
+    "url": "git+https://github.com/mozilla/passwordmgr-remote-settings-updater.git"
   },
   "license": "MPL-2.0",
   "bugs": {
-    "url": "https://github.com/mozilla/passwordmgr-related-realms-updater/issues"
+    "url": "https://github.com/mozilla/passwordmgr-remote-settings-updater/issues"
   },
-  "homepage": "https://github.com/mozilla/passwordmgr-related-realms-updater#readme",
+  "homepage": "https://github.com/mozilla/passwordmgr-remote-settings-updater#readme",
   "dependencies": {
     "atob": "^2.1.2",
     "btoa": "^1.2.1",

--- a/update-script.js
+++ b/update-script.js
@@ -20,8 +20,8 @@ const PASSWORD_RULES_API_ENDPOINT = "https://api.github.com/repos/apple/password
  *
  * Since this script should run once every two weeks, we don't need a GitHub token.
  * See also: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
- * @param {string} API_ENDPOINT either the `RELATED_REALMS_API_ENDPOINT` or `PASSWORD_RULES_API_ENDPOINT`
- * @return {String[][]} The related realms
+ * @param {string} API_ENDPOINT either `RELATED_REALMS_API_ENDPOINT` or `PASSWORD_RULES_API_ENDPOINT`
+ * @return {String[][]} The source records
  */
 const getSourceRecords = async (API_ENDPOINT) => {
   const response = await fetch(API_ENDPOINT, {
@@ -41,7 +41,7 @@ const arrayEquals = (a, b) => {
 };
 
 /**
- * Updates the existing record in Remote Settings with the updated data from Apple's GitHub repository
+ * Updates the existing record in the "websites-with-shared-credential-backends" Remote Settings collection with the updated data from Apple's GitHub repository
  *
  * @param {KintoClient} client KintoClient instance
  * @param {string} bucket Name of the Remote Settings bucket
@@ -80,7 +80,7 @@ const printSuccessMessage = () => {
 }
 
 /**
- * Determines if there are new records from the GitHub source
+ * Determines if there are new records from the GitHub source for the "websites-with-shared-credential-backends" collection
  *
  * @param {String[][]} sourceRecords Related realms from Apple's GitHub
  * @param {String[][]} destinationRecords Related realms from Remote Settings
@@ -119,7 +119,7 @@ const remoteSettingsRecordsToMap = (records) => {
 }
 
 /**
- * Creates and/or updates the existing records in Remote Settings with the updated data from Apple's GitHub repository
+ * Creates and/or updates the existing records in the "password-rules" Remote Settings collection with the updated data from Apple's GitHub repository
  *
  * @param {KintoClient} client KintoClient instance
  * @param {string} bucket Name of the Remote Settings bucket

--- a/update-script.js
+++ b/update-script.js
@@ -209,7 +209,6 @@ const createAndUpdateRelatedRealmsRecords = async (client, bucket) => {
  * @return {Number} 0 for success, 1 for failure.
  */
 const main = async () => {
-  debugger;
   if (FX_RS_WRITER_USER === "" || FX_RS_WRITER_PASS === "") {
     console.error("No username or password set, quitting!");
     return 1;

--- a/update-script.js
+++ b/update-script.js
@@ -142,7 +142,7 @@ const createAndUpdateRulesRecords = async (client, bucket) => {
       batchRecords.push(newRecord);
       console.log("Added new record to batch!", newRecord);
     }
-    if (oldRecord && oldRules !== comparisonRules) {
+    if (oldRecord && oldRules !== passwordRules) {
       let updatedRecord = { ...oldRecord, "password-rules": passwordRules };
       batchRecords.push(updatedRecord);
       console.log("Added updated record to batch!", updatedRecord);

--- a/update-script.js
+++ b/update-script.js
@@ -11,7 +11,6 @@ const FX_RS_WRITER_USER = AppConstants.FX_REMOTE_SETTINGS_WRITER_USER;
 const FX_RS_WRITER_PASS = AppConstants.FX_REMOTE_SETTINGS_WRITER_PASS;
 /** @type {String} */
 const SERVER_ADDRESS = AppConstants.FX_REMOTE_SETTINGS_WRITER_SERVER;
-// const BUCKET = "main-workspace";
 const BUCKET = "main";
 const RELATED_REALMS_API_ENDPOINT = "https://api.github.com/repos/apple/password-manager-resources/contents/quirks/websites-with-shared-credential-backends.json";
 const PASSWORD_RULES_API_ENDPOINT = "https://api.github.com/repos/apple/password-manager-resources/contents/quirks/password-rules.json";

--- a/update-script.js
+++ b/update-script.js
@@ -50,14 +50,15 @@ const arrayEquals = (a, b) => {
  * @param {string[][]} newRecord.relatedRealms Updated related realms array from GitHub
  */
 const updateRelatedRealmsRecord = async (client, bucket, newRecord) => {
-  await client.bucket(bucket).collection(RELATED_REALMS_COLLECTION_ID).updateRecord(newRecord);
-  const postServerData = await client.bucket(bucket).collection(RELATED_REALMS_COLLECTION_ID).getData();
+  const cid = RELATED_REALMS_COLLECTION_ID;
+  await client.bucket(bucket).collection(cid).updateRecord(newRecord);
+  const postServerData = await client.bucket(bucket).collection(cid).getData();
   const setDataObject = {
     status: "to-review",
     last_modified: postServerData.last_modified
   };
-  await client.bucket(bucket).collection(RELATED_REALMS_COLLECTION_ID).setData(setDataObject, { patch: true });
-  console.log(`Found new records, committed changes to ${RELATED_REALMS_COLLECTION_ID} collection.`);
+  await client.bucket(bucket).collection(cid).setData(setDataObject, { patch: true });
+  console.log(`Found new records, committed changes to ${cid} collection.`);
 };
 
 /**
@@ -67,12 +68,13 @@ const updateRelatedRealmsRecord = async (client, bucket, newRecord) => {
  * @param {string} bucket
  */
 const createRelatedRealmsRecord = async (client, bucket, sourceRecords) => {
-  const result = await client.bucket(bucket).collection(RELATED_REALMS_COLLECTION_ID).createRecord({
+  const cid = RELATED_REALMS_COLLECTION_ID;
+  const result = await client.bucket(bucket).collection(cid).createRecord({
     relatedRealms: sourceRecords
   });
-  const postServerData = await client.bucket(bucket).collection(RELATED_REALMS_COLLECTION_ID).getData();
-  await client.bucket(bucket).collection(RELATED_REALMS_COLLECTION_ID).setData({ status: "to-review", last_modified: postServerData.last_modified }, { patch: true });
-  console.log(`Added new record to ${RELATED_REALMS_COLLECTION_ID}`, result);
+  const postServerData = await client.bucket(bucket).collection(cid).getData();
+  await client.bucket(bucket).collection(cid).setData({ status: "to-review", last_modified: postServerData.last_modified }, { patch: true });
+  console.log(`Added new record to ${cid}`, result);
 };
 
 const printSuccessMessage = () => {

--- a/update-script.js
+++ b/update-script.js
@@ -17,7 +17,7 @@ const RELATED_REALMS_API_ENDPOINT = "https://api.github.com/repos/apple/password
 const PASSWORD_RULES_API_ENDPOINT = "https://api.github.com/repos/apple/password-manager-resources/contents/quirks/password-rules.json";
 
 /**
- * Fetches the source records from the API_ENDPOINT param
+ * Fetches the source records from the apiEndpoint param
  *
  * Since this script should run once every two weeks, we don't need a GitHub token.
  * See also: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting

--- a/update-script.js
+++ b/update-script.js
@@ -20,11 +20,11 @@ const PASSWORD_RULES_API_ENDPOINT = "https://api.github.com/repos/apple/password
  *
  * Since this script should run once every two weeks, we don't need a GitHub token.
  * See also: https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting
- * @param {string} API_ENDPOINT either `RELATED_REALMS_API_ENDPOINT` or `PASSWORD_RULES_API_ENDPOINT`
+ * @param {string} apiEndpoint either `RELATED_REALMS_API_ENDPOINT` or `PASSWORD_RULES_API_ENDPOINT`
  * @return {String[][]} The source records
  */
-const getSourceRecords = async (API_ENDPOINT) => {
-  const response = await fetch(API_ENDPOINT, {
+const getSourceRecords = async (apiEndpoint) => {
+  const response = await fetch(apiEndpoint, {
     headers: {
       "Accept": "application/vnd.github.v3.raw"
     }

--- a/update-script.js
+++ b/update-script.js
@@ -11,7 +11,8 @@ const FX_RS_WRITER_USER = AppConstants.FX_REMOTE_SETTINGS_WRITER_USER;
 const FX_RS_WRITER_PASS = AppConstants.FX_REMOTE_SETTINGS_WRITER_PASS;
 /** @type {String} */
 const SERVER_ADDRESS = AppConstants.FX_REMOTE_SETTINGS_WRITER_SERVER;
-const BUCKET = "main-workspace";
+// const BUCKET = "main-workspace";
+const BUCKET = "main";
 const RELATED_REALMS_API_ENDPOINT = "https://api.github.com/repos/apple/password-manager-resources/contents/quirks/websites-with-shared-credential-backends.json";
 const PASSWORD_RULES_API_ENDPOINT = "https://api.github.com/repos/apple/password-manager-resources/contents/quirks/password-rules.json";
 
@@ -135,15 +136,14 @@ const createAndUpdateRulesRecords = async (client, bucket) => {
 
   for (let domain in sourceRulesByDomain) {
     let passwordRules = sourceRulesByDomain[domain]["password-rules"];
-    let oldRecord = remoteSettingsRulesByDomain.get(domain);
-    let oldRules = oldRecord?.["password-rules"];
-    if (!oldRecord) {
+    let { id, "password-rules": oldRules } = remoteSettingsRulesByDomain.get(domain);
+    if (!id) {
       let newRecord = { "Domain": domain, "password-rules": passwordRules };
       batchRecords.push(newRecord);
       console.log("Added new record to batch!", newRecord);
     }
-    if (oldRecord && oldRules !== passwordRules) {
-      let updatedRecord = { ...oldRecord, "password-rules": passwordRules };
+    if (id && oldRules !== passwordRules) {
+      let updatedRecord = { id, "Domain": domain, "password-rules": passwordRules };
       batchRecords.push(updatedRecord);
       console.log("Added updated record to batch!", updatedRecord);
     }
@@ -209,6 +209,7 @@ const createAndUpdateRelatedRealmsRecords = async (client, bucket) => {
  * @return {Number} 0 for success, 1 for failure.
  */
 const main = async () => {
+  debugger;
   if (FX_RS_WRITER_USER === "" || FX_RS_WRITER_PASS === "") {
     console.error("No username or password set, quitting!");
     return 1;

--- a/update-script.js
+++ b/update-script.js
@@ -175,7 +175,6 @@ const createAndUpdateRulesRecords = async (client, bucket) => {
  * @return {Number} 0 for success, 1 for failure.
  */
 const main = async () => {
-  debugger;
   if (FX_RS_WRITER_USER === "" || FX_RS_WRITER_PASS === "") {
     console.error("No username or password set, quitting!");
     return 1;
@@ -189,7 +188,6 @@ const main = async () => {
     });
 
     let { data: relatedRealmsData } = await client.bucket(BUCKET).collection(RELATED_REALMS_COLLECTION_ID).listRecords();
-    // let relatedRealmsData = relatedRealmsRecords.data;
     let realmsGithubRecords = await getSourceRecords(RELATED_REALMS_API_ENDPOINT);
     let id = relatedRealmsData[0]?.id;
     // If there is no ID from Remote Settings, we need to create a new record in the related realms collection


### PR DESCRIPTION
These changes merge in the "password-rules" updater from the ["passwordmgr-password-rules-updater" repository](https://github.com/mozilla/passwordmgr-password-rules-updater). This PR assumes that the "related-realms-publisher" (or whichever account will be used to update these collections) Kinto account has access to create updates to the "password-rules" collection, so this PR **should not be merged until the Kinto account has privileges to update "password-rules"**. 

I have tested this against the dev server and the merged script works as expected, but having an extra review never hurts so @smarnach and @leplatrem when you two have a chance to review and verify the Kinto account, I'd appreciate it!