### PR TITLE
Add Docker step to run ruby script to generate legacy `websites-with-shared-credential-backends.json`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,19 @@
+# Apple removed `websites-with-shared-credential-backends.json` from the tree in favour of a new file format.
+# We currently don't support the new file format. In the meantime, we can use the
+# `convert-shared-credential-to-legacy-format.rb` script from apple to generate the legacy file.
+ARG RELATED_REALMS_LEGACY_FILE=websites-with-shared-credential-backends.json
+
+FROM ruby:3.3 as related-realms-legacy-generator
+
+RUN git clone https://github.com/apple/password-manager-resources
+
+WORKDIR /password-manager-resources
+
+ARG RELATED_REALMS_LEGACY_FILE
+RUN ./tools/convert-shared-credential-to-legacy-format.rb $RELATED_REALMS_LEGACY_FILE
+# Remove all other files, we only care about `RELATED_REALMS_LEGACY_FILE`
+RUN mv $RELATED_REALMS_LEGACY_FILE / && rm -rf /password-manager-resources
+
 FROM node:20-slim
 
 # add a non-privileged user for running the application
@@ -16,7 +32,8 @@ RUN npm install && \
 COPY ./update-script.js /app
 COPY ./app-constants.js /app
 COPY ./version.json /app/version.json
-
+COPY --from=related-realms-legacy-generator /$RELATED_REALMS_LEGACY_FILE /app/$RELATED_REALMS_LEGACY_FILE
 USER app
-
+ARG RELATED_REALMS_LEGACY_FILE
+ENV RELATED_REALMS_LEGACY_FILE=$RELATED_REALMS_LEGACY_FILE
 CMD ["node", "/app/update-script.js"]

--- a/app-constants.js
+++ b/app-constants.js
@@ -5,7 +5,8 @@ require("dotenv").config();
 const environmentVariables = [
   "SERVER",
   "AUTHORIZATION",
-]
+  "RELATED_REALMS_LEGACY_FILE",
+];
 
 const AppConstants = {};
 

--- a/update-script.js
+++ b/update-script.js
@@ -1,5 +1,6 @@
 const KintoClient = require("kinto-http").default;
 const btoa = require("btoa");
+const fs = require('fs/promises');
 const fetch = require("node-fetch");
 const AppConstants = require("./app-constants");
 
@@ -11,7 +12,7 @@ const AUTHORIZATION = AppConstants.AUTHORIZATION;
 /** @type {String} */
 const SERVER_ADDRESS = AppConstants.SERVER;
 const BUCKET = "main-workspace";
-const RELATED_REALMS_API_ENDPOINT = "https://api.github.com/repos/apple/password-manager-resources/contents/quirks/websites-with-shared-credential-backends.json";
+const RELATED_REALMS_LEGACY_FILE = AppConstants.RELATED_REALMS_LEGACY_FILE;
 const PASSWORD_RULES_API_ENDPOINT = "https://api.github.com/repos/apple/password-manager-resources/contents/quirks/password-rules.json";
 
 /**
@@ -175,7 +176,7 @@ const createAndUpdateRulesRecords = async (client, bucket) => {
  */
 const createAndUpdateRelatedRealmsRecords = async (client, bucket) => {
   let { data: relatedRealmsData } = await client.bucket(bucket).collection(RELATED_REALMS_COLLECTION_ID).listRecords();
-  let realmsGithubRecords = await getSourceRecords(RELATED_REALMS_API_ENDPOINT);
+  let realmsGithubRecords = JSON.parse(await fs.readFile(RELATED_REALMS_LEGACY_FILE, 'utf8'));
   let id = relatedRealmsData[0]?.id;
   // If there is no ID from Remote Settings, we need to create a new record in the related realms collection
   if (!id) {


### PR DESCRIPTION
Tracked in [Bug 1930541](https://bugzilla.mozilla.org/show_bug.cgi?id=1930541#c0)

## Context
Last week apple merged [a PR](https://github.com/apple/password-manager-resources/pull/850) which deletes the `websites-with-credential-backends.json` from the tree. We depend on this when updating our RS collection. The new format is described [here](https://github.com/apple/password-manager-resources/issues/464). As a quick workaround, we can just run [this ruby script](https://github.com/apple/password-manager-resources/blob/73f22d6661f2561964f25c08cebcc9ef8eae5ea6/tools/convert-shared-credential-to-legacy-format.rb#L10) as part of [the updater code](https://github.com/mozilla/passwordmgr-remote-settings-updater/blob/main/update-script.js#L27-L35) which will produce the legacy file.

## Description
This PR:
- Adds a docker ruby step to run `convert-shared-credential-to-legacy-format.rb` that generates `websites-with-shared-credential-backends.json`. 
- Modifies code to use the local `websites-with-shared-credential-backends.json` generated file instead of pulling from a url.